### PR TITLE
Adds tap gesture for item selection on iOS

### DIFF
--- a/Maui.NullableDateTimePicker/Controls/SelectList.cs
+++ b/Maui.NullableDateTimePicker/Controls/SelectList.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Controls.Shapes;
 using System.Collections;
 using System.Runtime.CompilerServices;
 
@@ -223,6 +223,20 @@ internal class SelectList : ContentView
                     }
                 }
             });
+            
+            if (DeviceInfo.Platform == DevicePlatform.iOS)
+            {
+                // Tap to select (works reliably on iOS)
+                var tap = new TapGestureRecognizer
+                {
+                    NumberOfTapsRequired = 1,
+                    Command = new Command(() =>
+                    {
+                        _collectionView.SelectedItem = border.BindingContext;
+                    })
+                };
+                border.GestureRecognizers.Add(tap);
+            }
 
             return border;
         });


### PR DESCRIPTION
Improves item selection on iOS by adding a tap gesture recognizer to each item. This allows users to reliably select items with a single tap.

This is a fix for #33  